### PR TITLE
feat: consolidate filter state across views and add bulk selection

### DIFF
--- a/docs/filter-architecture.md
+++ b/docs/filter-architecture.md
@@ -9,7 +9,7 @@ The Tycho Explorer uses a unified filter management system for both List View an
 ### 1. Filter State Management
 
 #### `useFilterManager` Hook (`/frontend/src/hooks/useFilterManager.ts`)
-The central hook that manages filter state for both views:
+The central hook that manages unified filter state across all views:
 
 ```typescript
 interface UseFilterManagerReturn {
@@ -26,22 +26,23 @@ interface UseFilterManagerReturn {
 - Works with token addresses internally (simpler state management)
 - Built-in duplicate prevention in toggle functions
 - Automatic persistence via `usePersistedFilters`
-- Consistent interface for both views
+- Unified filters that apply to both graph and list views
 
 #### `usePersistedFilters` Hook (`/frontend/src/hooks/usePersistedFilters.ts`)
 Handles localStorage operations:
 
 ```typescript
 // Storage key pattern:
-`tycho_${viewType}View_selected${DataType}_${chain}`
+`tycho_selected${DataType}_${chain}`
 
 // Examples:
-- tycho_listView_selectedTokens_Ethereum
-- tycho_graphView_selectedProtocols_Base
+- tycho_selectedTokens_Ethereum
+- tycho_selectedProtocols_Base
 ```
 
 **Features:**
 - Per-chain persistence (each chain maintains separate filters)
+- Unified filters across all views (graph and list share same filters)
 - 500ms debounced saves to prevent excessive writes
 - Error handling for localStorage operations
 - No default values - starts with empty arrays
@@ -100,7 +101,7 @@ const {
   toggleToken,
   toggleProtocol,
   resetFilters
-} = useFilterManager({ viewType: 'list', chain: selectedChain });
+} = useFilterManager({ chain: selectedChain });
 
 // Convert addresses to Token objects for display
 const selectedTokenObjects = useMemo(() => 
@@ -125,7 +126,7 @@ const {
   toggleToken,
   toggleProtocol,
   resetFilters
-} = useFilterManager({ viewType: 'graph', chain: selectedChain });
+} = useFilterManager({ chain: selectedChain });
 
 // Direct pass-through to GraphControls
 <GraphControls 
@@ -155,12 +156,13 @@ const {
   - Consistent with checkbox UI metaphor
 - **Previous Bug**: GraphControls used array replacement, causing single-select behavior
 
-### 3. Per-Chain Persistence
-- **Decision**: Separate filter state for each blockchain
+### 3. Unified Cross-View Persistence
+- **Decision**: Single filter state shared across graph and list views per chain
 - **Rationale**: 
-  - Users work with different tokens/protocols per chain
-  - Better UX: switching chains preserves context
-  - No filter clearing on chain switch
+  - Users expect filters to persist when switching views
+  - Simpler mental model - one set of filters per chain
+  - Reduces confusion about why filters differ between views
+  - Better UX: filtering in one view applies to both
 
 ### 4. Duplicate Prevention
 - **Decision**: Check for duplicates in toggle functions
@@ -208,7 +210,7 @@ const handleFilterChange = (filterKey, value, isSelected) => {
 **After:**
 ```typescript
 // Simple hook usage
-const { selectedTokenAddresses, toggleToken } = useFilterManager({ viewType, chain });
+const { selectedTokenAddresses, toggleToken } = useFilterManager({ chain });
 
 // Direct handlers
 const handleTokenToggle = (token, isSelected) => toggleToken(token.address, isSelected);
@@ -226,9 +228,10 @@ const handleTokenToggle = (token, isSelected) => toggleToken(token.address, isSe
 
 - [ ] Filters persist across page reloads
 - [ ] Each chain maintains separate filters
+- [ ] Filters remain active when switching between graph and list views
 - [ ] No duplicates when rapidly clicking
-- [ ] Both views behave identically
-- [ ] Reset clears filters and localStorage
+- [ ] Both views share the same filter state
+- [ ] Reset clears filters in both views simultaneously
 - [ ] Token search works by symbol only
 - [ ] Selected items appear at top of list
 - [ ] Virtual scrolling loads more items smoothly

--- a/frontend/src/components/dexscan/DexScanContent.tsx
+++ b/frontend/src/components/dexscan/DexScanContent.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import DexScanHeader from './DexScanHeader';
 import ListView from './ListView';
 import { PoolDataProvider, usePoolData } from './context/PoolDataContext';
 import GraphViewContent from './graph/GraphViewContent';
+import { useFilterManager } from '@/hooks/useFilterManager';
 
 // Import comet background assets
 import bgSmallComet from '@/assets/figma_generated/bg_small_comet.svg';
@@ -27,8 +28,21 @@ const DexScanContentMain = () => {
   const {
     poolsArray,
     highlightedPoolId,
-    highlightPool
+    highlightPool,
+    selectedChain
   } = usePoolData();
+  
+  // Calculate available protocols from all pools
+  const availableProtocols = useMemo(() => 
+    Array.from(new Set(poolsArray.map(pool => pool.protocol_system))).filter(Boolean).sort(),
+    [poolsArray]
+  );
+  
+  // Shared filter state for both views
+  const filters = useFilterManager({ 
+    chain: selectedChain,
+    availableProtocols 
+  });
 
   // Update the URL when the tab changes
   const handleTabChange = (tab: 'graph' | 'pools') => {
@@ -121,7 +135,7 @@ const DexScanContentMain = () => {
             position: "relative" 
           }
         }>
-          <GraphViewContent />
+          <GraphViewContent {...filters} />
         </div>
 
         <div ref={poolListContainerRef} style={{ 
@@ -132,6 +146,7 @@ const DexScanContentMain = () => {
             pools={poolsArray}
             highlightedPoolId={highlightedPoolId}
             onPoolSelect={highlightPool}
+            {...filters}
           />
         </div>
       </div>

--- a/frontend/src/components/dexscan/ListView.tsx
+++ b/frontend/src/components/dexscan/ListView.tsx
@@ -8,7 +8,6 @@ import PoolTable from './pools/PoolTable';
 import PoolListFilterBar from './pools/PoolListFilterBar';
 import PoolDetailSidebar from './PoolDetailSidebar'; // This component will be created later
 import { usePoolData } from './context/PoolDataContext';
-import { useFilterManager } from '@/hooks/useFilterManager';
 
 // TokenForFilter interface is removed. Using 'Token' from './types' directly.
 
@@ -30,6 +29,12 @@ interface PoolListViewProps {
   className?: string;
   highlightedPoolId?: string | null;
   onPoolSelect?: (poolId: string | null) => void;
+  selectedTokenAddresses: string[];
+  selectedProtocols: string[];
+  toggleToken: (address: string, isSelected: boolean) => void;
+  toggleProtocol: (protocol: string, isSelected: boolean) => void;
+  resetFilters: () => void;
+  isInitialized: boolean;
 }
 
 // Simplified renderTokens for text part, icons will be handled in PoolTable cell
@@ -43,7 +48,18 @@ const renderTokensText = (pool: Pool) => {
   }).join(' / ');
 };
 
-const ListView = ({ pools, className, highlightedPoolId, onPoolSelect }: PoolListViewProps) => {
+const ListView = ({ 
+  pools, 
+  className, 
+  highlightedPoolId, 
+  onPoolSelect,
+  selectedTokenAddresses,
+  selectedProtocols,
+  toggleToken,
+  toggleProtocol,
+  resetFilters: resetFilterState,
+  isInitialized
+}: PoolListViewProps) => {
   const { blockNumber, lastBlockTimestamp, estimatedBlockDuration, selectedChain } = usePoolData();
   
   const [selectedPool, setSelectedPool] = useState<Pool | null>(null);
@@ -53,15 +69,6 @@ const ListView = ({ pools, className, highlightedPoolId, onPoolSelect }: PoolLis
   });
   const [displayedPoolsCount, setDisplayedPoolsCount] = useState(INITIAL_DISPLAY_COUNT);
   const [isLoadingMore, setIsLoadingMore] = useState(false); // New state for loading indicator
-
-  // Use unified filter management
-  const {
-    selectedTokenAddresses,
-    selectedProtocols,
-    toggleToken,
-    toggleProtocol,
-    resetFilters: resetFilterState
-  } = useFilterManager({ viewType: 'list', chain: selectedChain });
 
   // Prepare data for filter popovers
   const allTokensForFilter = useMemo((): Token[] => { // Changed to Token[]

--- a/frontend/src/components/dexscan/common/filters/ProtocolFilterPopover.tsx
+++ b/frontend/src/components/dexscan/common/filters/ProtocolFilterPopover.tsx
@@ -30,6 +30,15 @@ export const ProtocolFilterPopover = ({
   const handleClearAll = () => {
     selectedProtocols.forEach(protocol => onProtocolToggle(protocol, false));
   };
+  
+  // Select all protocols
+  const handleSelectAll = () => {
+    protocols.forEach(protocol => {
+      if (!selectedProtocols.includes(protocol)) {
+        onProtocolToggle(protocol, true);
+      }
+    });
+  };
 
   return (
     <FilterPopover 
@@ -40,14 +49,30 @@ export const ProtocolFilterPopover = ({
       getItemLabel={(protocol) => getReadableProtocolName(protocol)}
       onClearAll={handleClearAll}
     >
-      {/* Selected Summary Bar */}
-      {selectedProtocols.length > 0 && (
-        <div className={`px-3 py-2 ${FILTER_STYLES.borderBottom}`}>
-          <span className={FILTER_STYLES.selectedCountText}>
-            {selectedProtocols.length} protocol{selectedProtocols.length !== 1 ? 's' : ''} selected
-          </span>
+      {/* Selection Header with Actions */}
+      <div className={`flex justify-between items-center px-3 py-2 ${FILTER_STYLES.borderBottom}`}>
+        <span className={`text-sm ${selectedProtocols.length > 0 ? FILTER_STYLES.selectedCountText : 'text-muted-foreground'}`}>
+          {selectedProtocols.length} of {protocols.length} selected
+        </span>
+        <div className="flex gap-1">
+          {selectedProtocols.length < protocols.length && (
+            <button
+              onClick={handleSelectAll}
+              className="text-xs px-2 py-1 rounded hover:bg-[#FFF4E010] text-[#FFF4E0] transition-colors"
+            >
+              Select All
+            </button>
+          )}
+          {selectedProtocols.length > 0 && (
+            <button
+              onClick={handleClearAll}
+              className="text-xs px-2 py-1 rounded hover:bg-[#FFF4E010] text-[#FFF4E0] transition-colors"
+            >
+              Clear All
+            </button>
+          )}
         </div>
-      )}
+      </div>
 
       <FilterList
         items={sortedProtocols}

--- a/frontend/src/components/dexscan/common/filters/TokenFilterPopover.tsx
+++ b/frontend/src/components/dexscan/common/filters/TokenFilterPopover.tsx
@@ -32,7 +32,7 @@ export const TokenFilterPopover = ({
   );
 
   // Filter tokens based on search - search by symbol and address
-  const filteredTokens = useFilterSearch(
+  const filteredTokens = useFilterSearch<Token>(
     sortedTokens,
     search,
     (token) => [token.symbol, token.address]
@@ -41,6 +41,16 @@ export const TokenFilterPopover = ({
   // Clear all selected tokens
   const handleClearAll = () => {
     selectedTokens.forEach(token => onTokenToggle(token, false));
+  };
+  
+  // Select all tokens (only from filtered list if searching)
+  const handleSelectAll = () => {
+    const tokensToSelect = search ? filteredTokens : tokens;
+    tokensToSelect.forEach(token => {
+      if (!selectedTokens.some(t => t.address === token.address)) {
+        onTokenToggle(token, true);
+      }
+    });
   };
 
   return (
@@ -58,6 +68,34 @@ export const TokenFilterPopover = ({
           onChange={setSearch}
           placeholder="Search by name or address"
         />
+      </div>
+      
+      {/* Selection Header with Actions */}
+      <div className={`flex justify-between items-center px-3 py-2 ${FILTER_STYLES.borderBottom}`}>
+        <span className={`text-sm ${selectedTokens.length > 0 ? FILTER_STYLES.selectedCountText : 'text-muted-foreground'}`}>
+          {selectedTokens.length} of {tokens.length} selected
+          {search && ` (${filteredTokens.length} shown)`}
+        </span>
+        <div className="flex gap-1">
+          {(search ? filteredTokens : tokens).some(token => 
+            !selectedTokens.some(t => t.address === token.address)
+          ) && (
+            <button
+              onClick={handleSelectAll}
+              className="text-xs px-2 py-1 rounded hover:bg-[#FFF4E010] text-[#FFF4E0] transition-colors"
+            >
+              Select {search ? 'Visible' : 'All'}
+            </button>
+          )}
+          {selectedTokens.length > 0 && (
+            <button
+              onClick={handleClearAll}
+              className="text-xs px-2 py-1 rounded hover:bg-[#FFF4E010] text-[#FFF4E0] transition-colors"
+            >
+              Clear All
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Sticky Selected Section */}

--- a/frontend/src/components/dexscan/graph/GraphViewContent.tsx
+++ b/frontend/src/components/dexscan/graph/GraphViewContent.tsx
@@ -4,7 +4,6 @@ import GraphView from './GraphView';
 import { useGraphData } from './hooks/useGraphData';
 import { GraphControls } from './GraphControls';
 import { usePoolData } from '../context/PoolDataContext'; // Corrected Import usePoolData
-import { useFilterManager } from '@/hooks/useFilterManager';
 
 // Import graph frame background asset
 import graphFrameBgArtboard from '@/assets/figma_generated/graph_frame_bg_artboard.png';
@@ -26,20 +25,27 @@ interface Pool {
   // Add other pool properties if accessed
 }
 
-const PoolGraphView: React.FC = () => {
+interface PoolGraphViewProps {
+  selectedTokenAddresses: string[];
+  selectedProtocols: string[];
+  toggleToken: (address: string, isSelected: boolean) => void;
+  toggleProtocol: (protocol: string, isSelected: boolean) => void;
+  resetFilters: () => void;
+  isInitialized: boolean;
+}
+
+const PoolGraphView: React.FC<PoolGraphViewProps> = ({
+  selectedTokenAddresses,
+  selectedProtocols,
+  toggleToken,
+  toggleProtocol,
+  resetFilters,
+  isInitialized
+}) => {
   // console.log(`DEBUG: GraphViewContent render`);
 
   // Get raw data for controls. Block info for GraphControls will come from useGraphData's return.
   const { pools: rawPoolsForControls, selectedChain } = usePoolData();
-
-  // Use unified filter management
-  const {
-    selectedTokenAddresses,
-    selectedProtocols,
-    toggleToken,
-    toggleProtocol,
-    resetFilters
-  } = useFilterManager({ viewType: 'graph', chain: selectedChain });
 
   // Derive data needed for GraphControls' dropdowns from raw data
   const allAvailableTokenNodes = useMemo(() => {

--- a/frontend/src/hooks/useFilterManager.ts
+++ b/frontend/src/hooks/useFilterManager.ts
@@ -2,28 +2,35 @@ import { useState, useEffect, useCallback } from 'react';
 import { usePersistedFilters } from './usePersistedFilters';
 
 interface UseFilterManagerOptions {
-  viewType: 'graph' | 'list';
   chain: string;
+  availableProtocols?: string[];
 }
 
-export function useFilterManager({ viewType, chain }: UseFilterManagerOptions) {
+export function useFilterManager({ chain, availableProtocols }: UseFilterManagerOptions) {
   const [selectedTokenAddresses, setSelectedTokenAddresses] = useState<string[]>([]);
   const [selectedProtocols, setSelectedProtocols] = useState<string[]>([]);
   const [isInitialized, setIsInitialized] = useState(false);
   
   const { loadFilters, saveFilters, clearFilters } = usePersistedFilters({
-    viewType,
     chain
   });
   
   // Load filters on mount or chain change
   useEffect(() => {
-    console.log(`[FilterManager] Loading filters for ${viewType} view on ${chain}`);
+    console.log(`[FilterManager] Loading filters for ${chain}`);
     const filters = loadFilters();
     setSelectedTokenAddresses(filters.selectedTokens);
-    setSelectedProtocols(filters.selectedProtocols);
+    
+    // Initialize protocols with all available if empty
+    if (filters.selectedProtocols.length === 0 && availableProtocols && availableProtocols.length > 0) {
+      console.log(`[FilterManager] No saved protocols, selecting all ${availableProtocols.length} available protocols`);
+      setSelectedProtocols(availableProtocols);
+    } else {
+      setSelectedProtocols(filters.selectedProtocols);
+    }
+    
     setIsInitialized(true);
-  }, [chain, viewType]); // Only depend on chain and viewType, not the function refs
+  }, [chain, availableProtocols]); // Depend on chain and availableProtocols
   
   // Save filters when they change (after initialization)
   useEffect(() => {

--- a/frontend/src/hooks/usePersistedFilters.ts
+++ b/frontend/src/hooks/usePersistedFilters.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 
 interface UsePersistedFiltersOptions {
-  viewType: 'graph' | 'list';
   chain: string;
 }
 
@@ -10,13 +9,13 @@ interface FilterData {
   selectedTokens: string[]; // Always stored as addresses
 }
 
-export function usePersistedFilters({ viewType, chain }: UsePersistedFiltersOptions) {
+export function usePersistedFilters({ chain }: UsePersistedFiltersOptions) {
   const [isLoading, setIsLoading] = useState(true);
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Construct storage keys based on view type and chain
+  // Construct storage keys based on chain
   const getStorageKey = (dataType: 'protocols' | 'tokens') => {
-    return `tycho_${viewType}View_selected${dataType.charAt(0).toUpperCase() + dataType.slice(1)}_${chain}`;
+    return `tycho_selected${dataType.charAt(0).toUpperCase() + dataType.slice(1)}_${chain}`;
   };
 
   // Load filters from localStorage
@@ -31,7 +30,7 @@ export function usePersistedFilters({ viewType, chain }: UsePersistedFiltersOpti
       const protocols = protocolsJson ? JSON.parse(protocolsJson) : [];
       const tokens = tokensJson ? JSON.parse(tokensJson) : [];
 
-      console.log(`[Persistence] Loaded filters for ${viewType} view on ${chain}:`, {
+      console.log(`[Persistence] Loaded filters for ${chain}:`, {
         protocols,
         tokens
       });
@@ -49,7 +48,7 @@ export function usePersistedFilters({ viewType, chain }: UsePersistedFiltersOpti
     } finally {
       setIsLoading(false);
     }
-  }, [viewType, chain]);
+  }, [chain]);
 
   // Save filters to localStorage with debouncing
   const saveFilters = useCallback((filters: FilterData) => {
@@ -67,7 +66,7 @@ export function usePersistedFilters({ viewType, chain }: UsePersistedFiltersOpti
         localStorage.setItem(protocolsKey, JSON.stringify(filters.selectedProtocols));
         localStorage.setItem(tokensKey, JSON.stringify(filters.selectedTokens));
 
-        console.log(`[Persistence] Saved filters for ${viewType} view on ${chain}:`, {
+        console.log(`[Persistence] Saved filters for ${chain}:`, {
           protocols: filters.selectedProtocols,
           tokens: filters.selectedTokens,
           protocolsKey,
@@ -77,7 +76,7 @@ export function usePersistedFilters({ viewType, chain }: UsePersistedFiltersOpti
         console.error('[Persistence] Error saving filters:', error);
       }
     }, 500); // 500ms debounce
-  }, [viewType, chain]);
+  }, [chain]);
 
   // Clear filters from localStorage
   const clearFilters = useCallback(() => {
@@ -88,11 +87,11 @@ export function usePersistedFilters({ viewType, chain }: UsePersistedFiltersOpti
       localStorage.removeItem(protocolsKey);
       localStorage.removeItem(tokensKey);
 
-      console.log(`[Persistence] Cleared filters for ${viewType} view on ${chain}`);
+      console.log(`[Persistence] Cleared filters for ${chain}`);
     } catch (error) {
       console.error('[Persistence] Error clearing filters:', error);
     }
-  }, [viewType, chain]);
+  }, [chain]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
- Remove view-specific filter persistence in favor of unified per-chain filters
- Filters now persist when switching between graph and list views
- Add "Select All" and "Clear All" buttons to filter popovers
- Initialize all protocols as selected by default for better UX
- Fix TypeScript type errors in TokenFilterPopover

Breaking change: Existing view-specific filters will not migrate to new format