### PR TITLE
feat: change version of github actions/checkout to v5

### DIFF
--- a/.github/workflows/production-deployment.yaml
+++ b/.github/workflows/production-deployment.yaml
@@ -39,7 +39,7 @@ jobs:
         run: sudo apt update && sudo apt install -y git
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ steps.generate-token.outputs.token }}
@@ -131,7 +131,7 @@ jobs:
         run: sudo apt update && sudo apt install -y git
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
[INFRA-158](https://propeller-heads.atlassian.net/browse/INFRA-158) - update ci/cd github **actions/checkout** to v5 due to upgrade ci/cd runner

[INFRA-158]: https://propeller-heads.atlassian.net/browse/INFRA-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ